### PR TITLE
Fix shared libs for gfortran

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/gfortran.patch
+++ b/recipe/gfortran.patch
@@ -23,7 +23,7 @@
 +SHARED_CPG_LIB="libcpgplot.so"
 +SHARED_LD="$CC -shared -o $SHARED_LIB"
 +SHARED_CPG_LD="$CC -shared -o $SHARED_CPG_LIB"
-+SHARED_LIB_LIBS="-L$PREFIX/lib -lpng -lgfortran"
++SHARED_LIB_LIBS="-L$PREFIX/lib -lX11 -lpng -lgfortran"
 +MCOMPL=""
 +MFLAGC=""
 +SYSDIR="$SYSDIR"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
     - osx.patch  # [osx]
 
 build:
-  number: 1005
+  number: 1006
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I ran into some problems when trying to build other packages using the new shared-library-version of libcpgplot if the `--as-needed` link option was in use.  This resulted from not explicitly specifying all required libraries (e.g., X11, libpng) when linking libcpgplot.so.  This is a simple one-line fix that addresses this.  
